### PR TITLE
fix: Change github secret to PROD secret

### DIFF
--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Copy secrets to .env
-        run: echo "${{ env.FEELIN_CORE_DEV_ENV }}" > .env
+        run: echo "${{ env.FEELIN_CORE_PROD_ENV }}" > .env
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1


### PR DESCRIPTION
- Fix prod-deploy GitHub Action to use `PROD_ENV` secret